### PR TITLE
Revert unnecessary quote causing error for postgres

### DIFF
--- a/templates/boilv4/postgres/111_bulk_upsert.go.tpl
+++ b/templates/boilv4/postgres/111_bulk_upsert.go.tpl
@@ -39,8 +39,8 @@ func (o {{$alias.UpSingular}}Slice) UpsertAll(ctx context.Context, exec boil.Con
 
 	columns := "DEFAULT VALUES"
 	if len(insert) != 0 {
-		columns = fmt.Sprintf("(\"%s\") VALUES %s",
-			strings.Join(insert, "\",\""),
+		columns = fmt.Sprintf("(%s) VALUES %s",
+			strings.Join(insert, ", "),
 			strmangle.Placeholders(dialect.UseIndexPlaceholders, len(insert)*len(o), 1, len(insert)),
 		)
 	}


### PR DESCRIPTION
## What

Revert of #2 as it causes redundant quote on posgres (sqlboiler v4.16.0)