### PR TITLE
sqlboiler has a new home (https://github.com/aarondl/sqlboiler) now

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Why?
 
-[SQLBoiler](https://github.com/volatiletech/sqlboiler) generated models don't come with supports for bulk operations such as bulk insert, upsert, delete and they don't provide any mechanism to overcome the RDBMS limitations such as max number of parameters in a query or statement.
+[SQLBoiler](https://github.com/aarondl/sqlboiler) generated models don't come with supports for bulk operations such as bulk insert, upsert, delete and they don't provide any mechanism to overcome the RDBMS limitations such as max number of parameters in a query or statement.
 
 Additional functionalities:
   - modelSlice.`InsertAll`
@@ -12,8 +12,8 @@ Additional functionalities:
   - modelSlice.`InsertIgnoreAll`
   - modelSlice.`InsertIgnoreAllByPage`: If you need ACID, call this function within a transaction.
   - modelSlice.`UpsertAll`
-  - modelSlice.`UpsertAllOnConflictColumns`: MySQL only. Workaround of [issues/328](https://github.com/volatiletech/sqlboiler/issues/328).
-  - modelSlice.`UpsertOnConflictColumns`: MySQL only. Workaround of [issues/328](https://github.com/volatiletech/sqlboiler/issues/328).
+  - modelSlice.`UpsertAllOnConflictColumns`: MySQL only. Workaround of [issues/328](https://github.com/aarondl/sqlboiler/issues/328).
+  - modelSlice.`UpsertOnConflictColumns`: MySQL only. Workaround of [issues/328](https://github.com/aarondl/sqlboiler/issues/328).
   - modelSlice.`UpsertAllByPage`: If you need ACID, call this function within a transaction.
   - modelSlice.`UpdateAllByPage`: If you need ACID, call this function within a transaction.
   - modelSlice.`DeleteAll`

--- a/templates/boilv4/mysql/111_bulk_upsert.go.tpl
+++ b/templates/boilv4/mysql/111_bulk_upsert.go.tpl
@@ -13,7 +13,7 @@ func (o {{$alias.UpSingular}}Slice) UpsertAll(ctx context.Context, exec boil.Con
 }
 
 // upsertAllOnConflictColumns upserts multiple rows with passing custom conflict columns to allow bypassing
-// single column conflict check (see bug https://github.com/volatiletech/sqlboiler/issues/328).
+// single column conflict check (see bug https://github.com/aarondl/sqlboiler/issues/328).
 // SQLBoiler only checks column conflict on single column only which is not correct as MySQL PK or UNIQUE index
 // can include multiple columns.
 // This function allows passing multiple conflict columns, but it cannot check whether they are correct or not.

--- a/templates/boilv4/mysql/114_upsert_on_conflict_columns.go.tpl
+++ b/templates/boilv4/mysql/114_upsert_on_conflict_columns.go.tpl
@@ -4,7 +4,7 @@
 
 // Upsert attempts an insert using an executor, and does an update or ignore on conflict with the specified columns.
 // This is copied from the built-in Upsert() function with accepting an extra param for conflict columns.
-// See bug https://github.com/volatiletech/sqlboiler/issues/328.
+// See bug https://github.com/aarondl/sqlboiler/issues/328.
 // SQLBoiler only checks column conflict on single column only which is not correct as MySQL PK or UNIQUE index
 // can include multiple columns.
 // This function allows passing multiple conflict columns, but it cannot check whether they are correct or not.

--- a/templates/boilv4/mysql/singleton/boil_extra.go.tpl
+++ b/templates/boilv4/mysql/singleton/boil_extra.go.tpl
@@ -2,8 +2,8 @@
 import (
     "unsafe"
 
-    "github.com/volatiletech/sqlboiler/v4/queries"
-    "github.com/volatiletech/sqlboiler/v4/queries/qm"
+    "github.com/aarondl/sqlboiler/v4/queries"
+    "github.com/aarondl/sqlboiler/v4/queries/qm"
 )
 
 const (

--- a/templates/boilv4/postgres/singleton/boil_extra.go.tpl
+++ b/templates/boilv4/postgres/singleton/boil_extra.go.tpl
@@ -2,8 +2,8 @@
 import (
     "unsafe"
 
-    "github.com/volatiletech/sqlboiler/v4/queries"
-    "github.com/volatiletech/sqlboiler/v4/queries/qm"
+    "github.com/aarondl/sqlboiler/v4/queries"
+    "github.com/aarondl/sqlboiler/v4/queries/qm"
 )
 
 const (


### PR DESCRIPTION
Hi,

the sqlboiler Repo was moved to https://github.com/aarondl/sqlboiler.
I adjusted imports and references to keep the generated extension files working.

Let me know if i missed something.

Thanks!

Regards,
Nico